### PR TITLE
[WIP] Add owl variant (fix #5)

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,4 +28,5 @@ module.exports = plugin(function({ addVariant }) {
   addVariant('children-last', childrenVariant('last', ':last-child'));
   addVariant('children-odd', childrenVariant('odd', ':nth-child(odd)'));
   addVariant('children-even', childrenVariant('even', ':nth-child(even)'));
+  addVariant('children-owl', childrenVariant('owl', '* + *'));
 });

--- a/index.js
+++ b/index.js
@@ -2,14 +2,13 @@ const plugin = require('tailwindcss/plugin');
 const _ = require('lodash');
 const selectorParser = require('postcss-selector-parser');
 
-const childrenVariant = function(pseudoClass = null, childrenSelector = null, classPrefix = null) {
+const childrenVariant = function(pseudoClass = null, childrenSelector = null) {
+  childrenSelector = childrenSelector ? childrenSelector : (pseudoClass ? `:${pseudoClass}` : '*');
   return ({ modifySelectors, separator }) => {
-    childrenSelector = childrenSelector ? childrenSelector : (pseudoClass ? `:${pseudoClass}` : '*');
-    classPrefix = classPrefix ? classPrefix : `children${pseudoClass ? (separator + pseudoClass) : ''}`;
     return modifySelectors(({ selector }) => {
       return selectorParser(selectors => {
         selectors.walkClasses(classNode => {
-          classNode.value = `${classPrefix}${separator}${classNode.value}`;
+          classNode.value = `children${pseudoClass ? (separator + pseudoClass) : ''}${separator}${classNode.value}`;
           classNode.parent.insertAfter(classNode, selectorParser().astSync(` > ${childrenSelector}`));
         });
       }).processSync(selector);
@@ -29,5 +28,5 @@ module.exports = plugin(function({ addVariant }) {
   addVariant('children-last', childrenVariant('last', ':last-child'));
   addVariant('children-odd', childrenVariant('odd', ':nth-child(odd)'));
   addVariant('children-even', childrenVariant('even', ':nth-child(even)'));
-  addVariant('owl', childrenVariant(null, '* + *', 'owl'));
+  addVariant('children-owl', childrenVariant('owl', '* + *'));
 });

--- a/index.js
+++ b/index.js
@@ -28,5 +28,5 @@ module.exports = plugin(function({ addVariant }) {
   addVariant('children-last', childrenVariant('last', ':last-child'));
   addVariant('children-odd', childrenVariant('odd', ':nth-child(odd)'));
   addVariant('children-even', childrenVariant('even', ':nth-child(even)'));
-  addVariant('children-owl', childrenVariant('owl', '* + *'));
+  addVariant('children-not-first', childrenVariant('not-first', '* + *'));
 });

--- a/index.js
+++ b/index.js
@@ -2,13 +2,14 @@ const plugin = require('tailwindcss/plugin');
 const _ = require('lodash');
 const selectorParser = require('postcss-selector-parser');
 
-const childrenVariant = function(pseudoClass = null, childrenSelector = null) {
-  childrenSelector = childrenSelector ? childrenSelector : (pseudoClass ? `:${pseudoClass}` : '*');
+const childrenVariant = function(pseudoClass = null, childrenSelector = null, classPrefix = null) {
   return ({ modifySelectors, separator }) => {
+    childrenSelector = childrenSelector ? childrenSelector : (pseudoClass ? `:${pseudoClass}` : '*');
+    classPrefix = classPrefix ? classPrefix : `children${pseudoClass ? (separator + pseudoClass) : ''}`;
     return modifySelectors(({ selector }) => {
       return selectorParser(selectors => {
         selectors.walkClasses(classNode => {
-          classNode.value = `children${pseudoClass ? (separator + pseudoClass) : ''}${separator}${classNode.value}`;
+          classNode.value = `${classPrefix}${separator}${classNode.value}`;
           classNode.parent.insertAfter(classNode, selectorParser().astSync(` > ${childrenSelector}`));
         });
       }).processSync(selector);
@@ -28,5 +29,5 @@ module.exports = plugin(function({ addVariant }) {
   addVariant('children-last', childrenVariant('last', ':last-child'));
   addVariant('children-odd', childrenVariant('odd', ':nth-child(odd)'));
   addVariant('children-even', childrenVariant('even', ':nth-child(even)'));
-  addVariant('children-owl', childrenVariant('owl', '* + *'));
+  addVariant('owl', childrenVariant(null, '* + *', 'owl'));
 });

--- a/test.js
+++ b/test.js
@@ -75,7 +75,7 @@ test('the children variant can be generated before the default variant', () => {
 });
 
 test('all the variants are working', () => {
-  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'hover', 'children-focus', 'focus', 'children-focus-within', 'focus-within', 'children-active', 'active', 'children-visited', 'visited', 'children-disabled', 'disabled', 'owl']).then(css => {
+  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'hover', 'children-focus', 'focus', 'children-focus-within', 'focus-within', 'children-active', 'active', 'children-visited', 'visited', 'children-disabled', 'disabled', 'children-owl']).then(css => {
     expect(css).toMatchCss(`
       .children\\:block > * {
         display: block;
@@ -131,7 +131,7 @@ test('all the variants are working', () => {
       .disabled\\:block:disabled {
         display: block;
       }
-      .owl\\:block > * + * {
+      .children\\:owl\\:block > * + * {
         display: block;
       }
     `);
@@ -139,7 +139,7 @@ test('all the variants are working', () => {
 });
 
 test('all variants can be chained with the responsive variant', () => {
-  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'children-focus', 'children-focus-within', 'children-active', 'children-visited', 'children-disabled', 'owl', 'responsive']).then(css => {
+  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'children-focus', 'children-focus-within', 'children-active', 'children-visited', 'children-disabled', 'children-owl', 'responsive']).then(css => {
     expect(css).toMatchCss(`
       .children\\:block > * {
         display: block;
@@ -177,7 +177,7 @@ test('all variants can be chained with the responsive variant', () => {
       .children\\:disabled\\:block > :disabled {
         display: block;
       }
-      .owl\\:block > * + * {
+      .children\\:owl\\:block > * + * {
         display: block;
       }
       @media (min-width: 640px) {
@@ -217,7 +217,7 @@ test('all variants can be chained with the responsive variant', () => {
         .sm\\:children\\:disabled\\:block > :disabled {
           display: block;
         }
-        .sm\\:owl\\:block > * + * {
+        .sm\\:children\\:owl\\:block > * + * {
           display: block;
         }
       }

--- a/test.js
+++ b/test.js
@@ -75,7 +75,7 @@ test('the children variant can be generated before the default variant', () => {
 });
 
 test('all the variants are working', () => {
-  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'hover', 'children-focus', 'focus', 'children-focus-within', 'focus-within', 'children-active', 'active', 'children-visited', 'visited', 'children-disabled', 'disabled', 'children-owl']).then(css => {
+  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'hover', 'children-focus', 'focus', 'children-focus-within', 'focus-within', 'children-active', 'active', 'children-visited', 'visited', 'children-disabled', 'disabled', 'children-not-first']).then(css => {
     expect(css).toMatchCss(`
       .children\\:block > * {
         display: block;
@@ -131,7 +131,7 @@ test('all the variants are working', () => {
       .disabled\\:block:disabled {
         display: block;
       }
-      .children\\:owl\\:block > * + * {
+      .children\\:not-first\\:block > * + * {
         display: block;
       }
     `);
@@ -139,7 +139,7 @@ test('all the variants are working', () => {
 });
 
 test('all variants can be chained with the responsive variant', () => {
-  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'children-focus', 'children-focus-within', 'children-active', 'children-visited', 'children-disabled', 'children-owl', 'responsive']).then(css => {
+  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'children-focus', 'children-focus-within', 'children-active', 'children-visited', 'children-disabled', 'children-not-first', 'responsive']).then(css => {
     expect(css).toMatchCss(`
       .children\\:block > * {
         display: block;
@@ -177,7 +177,7 @@ test('all variants can be chained with the responsive variant', () => {
       .children\\:disabled\\:block > :disabled {
         display: block;
       }
-      .children\\:owl\\:block > * + * {
+      .children\\:not-first\\:block > * + * {
         display: block;
       }
       @media (min-width: 640px) {
@@ -217,7 +217,7 @@ test('all variants can be chained with the responsive variant', () => {
         .sm\\:children\\:disabled\\:block > :disabled {
           display: block;
         }
-        .sm\\:children\\:owl\\:block > * + * {
+        .sm\\:children\\:not-first\\:block > * + * {
           display: block;
         }
       }

--- a/test.js
+++ b/test.js
@@ -75,7 +75,7 @@ test('the children variant can be generated before the default variant', () => {
 });
 
 test('all the variants are working', () => {
-  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'hover', 'children-focus', 'focus', 'children-focus-within', 'focus-within', 'children-active', 'active', 'children-visited', 'visited', 'children-disabled', 'disabled']).then(css => {
+  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'hover', 'children-focus', 'focus', 'children-focus-within', 'focus-within', 'children-active', 'active', 'children-visited', 'visited', 'children-disabled', 'disabled', 'children-owl']).then(css => {
     expect(css).toMatchCss(`
       .children\\:block > * {
         display: block;
@@ -131,12 +131,15 @@ test('all the variants are working', () => {
       .disabled\\:block:disabled {
         display: block;
       }
+      .children\\:owl\\:block > * + * {
+        display: block;
+      }
     `);
   });
 });
 
 test('all variants can be chained with the responsive variant', () => {
-  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'children-focus', 'children-focus-within', 'children-active', 'children-visited', 'children-disabled', 'responsive']).then(css => {
+  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'children-focus', 'children-focus-within', 'children-active', 'children-visited', 'children-disabled', 'children-owl', 'responsive']).then(css => {
     expect(css).toMatchCss(`
       .children\\:block > * {
         display: block;
@@ -174,6 +177,9 @@ test('all variants can be chained with the responsive variant', () => {
       .children\\:disabled\\:block > :disabled {
         display: block;
       }
+      .children\\:owl\\:block > * + * {
+        display: block;
+      }
       @media (min-width: 640px) {
         .sm\\:children\\:block > * {
           display: block;
@@ -209,6 +215,9 @@ test('all variants can be chained with the responsive variant', () => {
           display: block;
         }
         .sm\\:children\\:disabled\\:block > :disabled {
+          display: block;
+        }
+        .sm\\:children\\:owl\\:block > * + * {
           display: block;
         }
       }

--- a/test.js
+++ b/test.js
@@ -75,7 +75,7 @@ test('the children variant can be generated before the default variant', () => {
 });
 
 test('all the variants are working', () => {
-  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'hover', 'children-focus', 'focus', 'children-focus-within', 'focus-within', 'children-active', 'active', 'children-visited', 'visited', 'children-disabled', 'disabled', 'children-owl']).then(css => {
+  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'hover', 'children-focus', 'focus', 'children-focus-within', 'focus-within', 'children-active', 'active', 'children-visited', 'visited', 'children-disabled', 'disabled', 'owl']).then(css => {
     expect(css).toMatchCss(`
       .children\\:block > * {
         display: block;
@@ -131,7 +131,7 @@ test('all the variants are working', () => {
       .disabled\\:block:disabled {
         display: block;
       }
-      .children\\:owl\\:block > * + * {
+      .owl\\:block > * + * {
         display: block;
       }
     `);
@@ -139,7 +139,7 @@ test('all the variants are working', () => {
 });
 
 test('all variants can be chained with the responsive variant', () => {
-  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'children-focus', 'children-focus-within', 'children-active', 'children-visited', 'children-disabled', 'children-owl', 'responsive']).then(css => {
+  return generatePluginCss(['children', 'default', 'children-first', 'children-last', 'children-odd', 'children-even', 'children-hover', 'children-focus', 'children-focus-within', 'children-active', 'children-visited', 'children-disabled', 'owl', 'responsive']).then(css => {
     expect(css).toMatchCss(`
       .children\\:block > * {
         display: block;
@@ -177,7 +177,7 @@ test('all variants can be chained with the responsive variant', () => {
       .children\\:disabled\\:block > :disabled {
         display: block;
       }
-      .children\\:owl\\:block > * + * {
+      .owl\\:block > * + * {
         display: block;
       }
       @media (min-width: 640px) {
@@ -217,7 +217,7 @@ test('all variants can be chained with the responsive variant', () => {
         .sm\\:children\\:disabled\\:block > :disabled {
           display: block;
         }
-        .sm\\:children\\:owl\\:block > * + * {
+        .sm\\:owl\\:block > * + * {
           display: block;
         }
       }


### PR DESCRIPTION
The way this branch works is cleaner. :)

Using the `childrenVariant` method you provide, there is a `children` prefix on every utility. 

It may make sense for the previous variants, but I think it's kind of strange for the `owl` variant, because the meaning of the `owl` selector is that it's going to select all children except the first. So I would say that `owl:mt-2` instead of `children:owl:mt-2` makes more sense. 

Or maybe it can be renamed into something like `not-first`? It would make more sense, although `children:not-first:mt-2` is way longer... 